### PR TITLE
Add more detailed configuration example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ gem 'tachikoma', github: 'sanemat/tachikoma'
 ```
  /Rakefile
 require 'bundler/setup'
+require 'tachikoma'
 require 'tachikoma/tasks'
 ```
 
@@ -47,6 +48,8 @@ Configure example
 
 ```ruby
 # /Rakefile
+Tachikoma.root_path = File.expand_path(__FILE__) # reset `root_path`
+
 namespace :tachikoma do
   @default_timestamp_format = '%Y-%m-%d-%H-%M-%S%z'
 end


### PR DESCRIPTION
As a result of https://github.com/sanemat/tachikoma/commit/6a23606c33af6ee46e6bfcef943ca0294f533205, the way to configure tachikoma's `root_path` changed.
This commit reflects it.
