### PR TITLE
Use tachikoma at github instead of gemized one

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 ruby '2.0.0'
 
-gem 'tachikoma'
+gem 'tachikoma', github: 'sanemat/tachikoma'
 gem 'oj'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,35 +1,33 @@
+GIT
+  remote: git://github.com/sanemat/tachikoma.git
+  revision: 84c9987f199d31ff9f913d0ddc99562a966cd818
+  specs:
+    tachikoma (3.0.10.beta)
+      json
+      octokit (>= 2, < 3)
+      rake
+      safe_yaml
+
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.5)
     faraday (0.8.8)
       multipart-post (~> 1.2.0)
-    faraday_middleware (0.9.0)
-      faraday (>= 0.7.4, < 0.9)
-    hashie (2.0.5)
     json (1.8.0)
-    multi_json (1.8.0)
     multipart-post (1.2.0)
-    netrc (0.7.7)
-    octokit (1.25.0)
-      addressable (~> 2.2)
-      faraday (~> 0.8)
-      faraday_middleware (~> 0.9)
-      hashie (~> 2.0)
-      multi_json (~> 1.3)
-      netrc (~> 0.7.7)
+    octokit (2.1.2)
+      sawyer (~> 0.5.0)
     oj (2.1.4)
     rake (10.1.0)
-    safe_yaml (0.9.5)
-    tachikoma (3.0.8)
-      json
-      octokit (< 2)
-      rake
-      safe_yaml
+    safe_yaml (0.9.7)
+    sawyer (0.5.0)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   oj
-  tachikoma
+  tachikoma!


### PR DESCRIPTION
I want to use this repo for checking tachikoma master, so I change reference  to github master instead of rubygems.
